### PR TITLE
Add experimental Go server with Postgres login

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,22 @@ run `setup.bat`
 After setup completed, press Enter and exit setup
 
 run `run.bat` and open [localhost:5000](http://localhost:5000).
+
+## Go server (experimental)
+
+An experimental Go implementation with PostgreSQL based login is located in
+`go-server`. It requires Go 1.20+.
+
+### Setup
+
+1. Create a PostgreSQL database and apply `go-server/schema.sql`.
+2. Set the environment variable `DATABASE_URL` or adjust the default connection
+   string in `go-server/main.go`.
+3. Start the server with:
+
+```bash
+go run ./go-server
+```
+
+The server will listen on `http://localhost:8080` and exposes simple register,
+login and admin pages.

--- a/css/animations.css
+++ b/css/animations.css
@@ -1,0 +1,8 @@
+.fade-in {
+    animation: fadeIn 0.6s ease-in-out;
+}
+
+@keyframes fadeIn {
+    from {opacity: 0; transform: translateY(10px);}
+    to {opacity: 1; transform: translateY(0);}
+}

--- a/go-server/go.mod
+++ b/go-server/go.mod
@@ -1,0 +1,11 @@
+module bbb-player/go-server
+
+go 1.20
+
+require (
+    github.com/gin-contrib/sessions v0.0.5
+    github.com/gin-contrib/sessions/cookie v0.0.0-20221117134541-12a7d93a9f1c
+    github.com/gin-gonic/gin v1.9.0
+    github.com/lib/pq v1.10.9
+    golang.org/x/crypto v0.16.0
+)

--- a/go-server/main.go
+++ b/go-server/main.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gin-gonic/gin"
+	_ "github.com/lib/pq"
+	"golang.org/x/crypto/bcrypt"
+)
+
+var db *sql.DB
+
+func main() {
+	var err error
+	connStr := os.Getenv("DATABASE_URL")
+	if connStr == "" {
+		connStr = "user=postgres password=postgres dbname=bbb sslmode=disable"
+	}
+	db, err = sql.Open("postgres", connStr)
+	if err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		log.Fatalf("failed to ping database: %v", err)
+	}
+
+	r := gin.Default()
+	store := cookie.NewStore([]byte("secret"))
+	r.Use(sessions.Sessions("bbb-session", store))
+
+	r.LoadHTMLGlob("templates/*")
+
+	r.GET("/register", showRegister)
+	r.POST("/register", register)
+	r.GET("/login", showLogin)
+	r.POST("/login", login)
+	r.GET("/logout", logout)
+	r.GET("/admin", adminPanel)
+
+	log.Println("Server running at http://localhost:8080")
+	r.Run(":8080")
+}
+
+func showRegister(c *gin.Context) {
+	c.HTML(http.StatusOK, "register.html", nil)
+}
+
+func register(c *gin.Context) {
+	username := c.PostForm("username")
+	password := c.PostForm("password")
+	if username == "" || password == "" {
+		c.HTML(http.StatusBadRequest, "register.html", gin.H{"error": "fill all fields"})
+		return
+	}
+	hashed, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		c.HTML(http.StatusInternalServerError, "register.html", gin.H{"error": err.Error()})
+		return
+	}
+	_, err = db.Exec("insert into users(username, password_hash) values($1,$2)", username, string(hashed))
+	if err != nil {
+		c.HTML(http.StatusInternalServerError, "register.html", gin.H{"error": err.Error()})
+		return
+	}
+	c.Redirect(http.StatusSeeOther, "/login")
+}
+
+func showLogin(c *gin.Context) {
+	c.HTML(http.StatusOK, "login.html", nil)
+}
+
+func login(c *gin.Context) {
+	username := c.PostForm("username")
+	password := c.PostForm("password")
+
+	var hash string
+	var isAdmin bool
+	err := db.QueryRow("select password_hash, is_admin from users where username=$1", username).Scan(&hash, &isAdmin)
+	if err != nil {
+		c.HTML(http.StatusUnauthorized, "login.html", gin.H{"error": "invalid credentials"})
+		return
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)); err != nil {
+		c.HTML(http.StatusUnauthorized, "login.html", gin.H{"error": "invalid credentials"})
+		return
+	}
+	session := sessions.Default(c)
+	session.Set("user", username)
+	session.Set("is_admin", isAdmin)
+	session.Save()
+	c.Redirect(http.StatusSeeOther, "/admin")
+}
+
+func logout(c *gin.Context) {
+	session := sessions.Default(c)
+	session.Clear()
+	session.Save()
+	c.Redirect(http.StatusSeeOther, "/login")
+}
+
+func adminPanel(c *gin.Context) {
+	session := sessions.Default(c)
+	user := session.Get("user")
+	isAdmin := session.Get("is_admin")
+	if user == nil || isAdmin != true {
+		c.Redirect(http.StatusSeeOther, "/login")
+		return
+	}
+	rows, err := db.Query("select id, username, is_admin from users order by id")
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer rows.Close()
+	type uinfo struct {
+		ID       int
+		Username string
+		Admin    bool
+	}
+	var users []uinfo
+	for rows.Next() {
+		var u uinfo
+		if err := rows.Scan(&u.ID, &u.Username, &u.Admin); err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+		users = append(users, u)
+	}
+	c.HTML(http.StatusOK, "admin.html", gin.H{"users": users, "user": user})
+}

--- a/go-server/schema.sql
+++ b/go-server/schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    is_admin BOOLEAN DEFAULT FALSE
+);

--- a/go-server/templates/admin.html
+++ b/go-server/templates/admin.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+    <h2>Admin Panel</h2>
+    <p>Welcome, {{.user}}</p>
+    <a href="/logout">Logout</a>
+    <table border="1">
+        <tr><th>ID</th><th>Username</th><th>Admin</th></tr>
+        {{range .users}}
+        <tr>
+            <td>{{.ID}}</td><td>{{.Username}}</td><td>{{.Admin}}</td>
+        </tr>
+        {{end}}
+    </table>
+</body>
+</html>

--- a/go-server/templates/login.html
+++ b/go-server/templates/login.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+    <h2>Login</h2>
+    {{if .error}}<p style="color:red">{{.error}}</p>{{end}}
+    <form method="POST" action="/login">
+        <input name="username" placeholder="Username">
+        <input name="password" type="password" placeholder="Password">
+        <button type="submit">Login</button>
+    </form>
+    <a href="/register">Register</a>
+</body>
+</html>

--- a/go-server/templates/register.html
+++ b/go-server/templates/register.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+    <h2>Register</h2>
+    {{if .error}}<p style="color:red">{{.error}}</p>{{end}}
+    <form method="POST" action="/register">
+        <input name="username" placeholder="Username">
+        <input name="password" type="password" placeholder="Password">
+        <button type="submit">Register</button>
+    </form>
+    <a href="/login">Login</a>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -7,9 +7,10 @@
 
 		<title>دانلود و پخش جلسات BBB</title>
 
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-rtl.min.css') }}">
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/vazir.css') }}">
+                <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
+                <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-rtl.min.css') }}">
+                <link rel="stylesheet" href="{{ url_for('static', filename='css/vazir.css') }}">
+                <link rel="stylesheet" href="{{ url_for('static', filename='css/animations.css') }}">
 	</head>
 
 	<style>
@@ -29,7 +30,7 @@
 
 		<div class="container">
 			<br><br><br>
-			<div class="dl-new-meeting card">
+                        <div class="dl-new-meeting card fade-in">
 				<h5 class="card-header">دانلود جلسه</h5>
 				<div class="card-body">
 					<p class="message card-text"><b>{{ message }}</b></p>
@@ -54,7 +55,7 @@
 			</div>
 			<br>
 
-			<table class="table table-striped table-hover">
+                        <table class="table table-striped table-hover fade-in">
 				<thead class="thead-dark">
 					<tr>
 						<th>#</th>


### PR DESCRIPTION
## Summary
- add a small experimental Go server with login/registration backed by PostgreSQL
- document new Go server in README
- add simple fade-in animation CSS and apply to index page

## Testing
- `python3 -m py_compile bbb-player.py`
- `go build ./go-server` *(fails: cannot find module or Go sum entry)*

------
https://chatgpt.com/codex/tasks/task_b_684993f3089c83279213c5ca3653a75b